### PR TITLE
ci(workflows): remove lint step from workflow

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -33,8 +33,5 @@ jobs:
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile
 
-      - name: Lint
-        run: pnpm lint
-
       - name: ${{ inputs.cmd }}
         run: ${{ inputs.cmd }}


### PR DESCRIPTION
Removed the lint step from the GitHub Actions workflow to streamline the process.