### PR TITLE
ci: remove generate step from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,6 @@ jobs:
     with:
       cmd: pnpm lint
 
-  generate:
-    uses: ./.github/workflows/run.yml
-    secrets: inherit
-    with:
-      cmd: pnpm generate && git diff --exit-code
-
   build:
     uses: ./.github/workflows/run.yml
     secrets: inherit


### PR DESCRIPTION
Removed the generate step in the CI pipeline as it is redundant.