### PR TITLE
chore(ci): disable caching for generate task

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -14,6 +14,7 @@
 			]
 		},
 		"generate": {
+			"cache": false,
 			"dependsOn": ["^generate"]
 		},
 		"dev": {


### PR DESCRIPTION
Disabled caching for the generate task in turbo.json to adjust task execution behavior.