### PR TITLE
fix(chat): filter provider keys by active/deleted status

### DIFF
--- a/apps/api/src/content/keys-provider.ts
+++ b/apps/api/src/content/keys-provider.ts
@@ -99,6 +99,9 @@ keysProvider.openapi(create, async (c) => {
 	// Check if a provider key already exists for this provider and project
 	const existingKey = await db.query.providerKey.findFirst({
 		where: {
+			status: {
+				ne: "deleted",
+			},
 			provider: {
 				eq: provider,
 			},

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -183,6 +183,9 @@ chat.openapi(completions, async (c) => {
 	if (usedProvider === "openllm" && usedModel === "auto") {
 		const providerKeys = await db.query.providerKey.findMany({
 			where: {
+				status: {
+					eq: "active",
+				},
 				projectId: {
 					eq: apiKey.projectId,
 				},
@@ -221,6 +224,9 @@ chat.openapi(completions, async (c) => {
 		} else {
 			const providerKeys = await db.query.providerKey.findMany({
 				where: {
+					status: {
+						eq: "active",
+					},
 					projectId: {
 						eq: apiKey.projectId,
 					},
@@ -278,6 +284,9 @@ chat.openapi(completions, async (c) => {
 	// Get the provider key for the selected provider
 	const providerKey = await db.query.providerKey.findFirst({
 		where: {
+			status: {
+				eq: "active",
+			},
 			projectId: {
 				eq: apiKey.projectId,
 			},

--- a/apps/ui/src/components/provider-keys/provider-keys-list.tsx
+++ b/apps/ui/src/components/provider-keys/provider-keys-list.tsx
@@ -60,7 +60,7 @@ export function ProviderKeysList() {
 	const deleteMutation = useDeleteProviderKey();
 	const toggleMutation = useToggleProviderKeyStatus();
 
-	const keys = data?.providerKeys;
+	const keys = data?.providerKeys.filter((key) => key.status !== "deleted");
 
 	const deleteKey = (id: string) => {
 		deleteMutation.mutate(id);

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -6,7 +6,6 @@ import {
 	real,
 	text,
 	timestamp,
-	unique,
 } from "drizzle-orm/pg-core";
 import { customAlphabet } from "nanoid";
 
@@ -107,7 +106,7 @@ export const providerKey = pgTable(
 		id: text().primaryKey().notNull().$defaultFn(shortid),
 		createdAt: timestamp().notNull().defaultNow(),
 		updatedAt: timestamp().notNull().defaultNow(),
-		token: text().notNull().unique(),
+		token: text().notNull(),
 		provider: text().notNull(),
 		baseUrl: text(), // Optional base URL for custom providers
 		status: text({
@@ -115,7 +114,7 @@ export const providerKey = pgTable(
 		}).default("active"),
 		projectId: text().notNull(),
 	},
-	(table) => [unique().on(table.projectId, table.provider)],
+	(table) => [],
 );
 
 export const log = pgTable("log", {


### PR DESCRIPTION
Ensure only active provider keys are used in operations and exclude deleted keys from UI and queries.

BREAKING CHANGE: Removed unique constraint on provider keys schema.